### PR TITLE
Add Godot's Default .gitattributes File

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf


### PR DESCRIPTION
This is the default ".gitattributes" file Godot generates with a new project. It ensures there's no unnecessary file changes from CRLF to LF or the other way around. The project is fortunately already set to LF, Godot's default value, so it was left that way.
Various things on Windows may attempt to change this without the file correcting it, so this'd save me & maybe others some headaches in the future.