### PR TITLE
Fix Scene Tree Focus Crash

### DIFF
--- a/barkvr-system/ui/3dPanel/editmode/scene_inspector_rework.gd
+++ b/barkvr-system/ui/3dPanel/editmode/scene_inspector_rework.gd
@@ -120,7 +120,7 @@ func selection_focus() -> void:
 	if !is_instance_valid(node_tree.get_next_selected(null)): return
 
 	var new_target = node_tree.get_next_selected(null).get_metadata(0).node
-	node_tree.hashed_tree_clear()
+	node_tree.tree_clear()
 	node_tree.create_item().set_text(0, "")
 	set_root(new_target)
 	node_tree.check_children()


### PR DESCRIPTION
A function still had an older name, causing a crash when trying to focus a node in the tree.