### PR TITLE
Fix Inspector Rendering On Top

### DIFF
--- a/barkvr-system/ui/3dPanel/editmode/unified editor/unified_inspector_3d.tscn
+++ b/barkvr-system/ui/3dPanel/editmode/unified editor/unified_inspector_3d.tscn
@@ -43,5 +43,4 @@ script = ExtResource("1_2f3s4")
 background_material = SubResource("StandardMaterial3D_o5mcw")
 _auto_load_ui = ExtResource("2_8d3jq")
 render_priority = 124
-on_top = true
 metadata/grabbable = true


### PR DESCRIPTION
Tested in both VR and Desktop, stops rendering the Inspector on top of everything.
Closes #70.